### PR TITLE
Few preflight checks

### DIFF
--- a/awx_collection/plugins/action/generate_mesh.py
+++ b/awx_collection/plugins/action/generate_mesh.py
@@ -90,7 +90,7 @@ class ActionModule(ActionBase):
 
         return None
 
-    def preflight_verify_node_type(self, task_vars=None, group_name=None, valid_types=None,):
+    def assert_verify_node_type(self, task_vars=None, group_name=None, valid_types=None,):
         """
         Members of given group_name must have a valid node_type.
         """
@@ -104,7 +104,7 @@ class ActionModule(ActionBase):
         return
 
 
-    def preflight_unique_group(self, task_vars=None):
+    def assert_unique_group(self, task_vars=None):
         """
         A given host cannot be part of the automationcontroller and execution_nodes group.
         """
@@ -125,10 +125,9 @@ class ActionModule(ActionBase):
         if task_vars is None:
             task_vars = dict()
 
-        # Series of preflight that must pass
-        self.preflight_unique_group(task_vars)
-        self.preflight_verify_node_type(task_vars, group_name='automationcontroller', valid_types=CONTROLLER_NODE_TYPES)
-        self.preflight_verify_node_type(task_vars, group_name='execution_nodes', valid_types=EXECUTION_NODE_TYPES)
+        self.assert_unique_group(task_vars)
+        self.assert_verify_node_type(task_vars, group_name='automationcontroller', valid_types=CONTROLLER_NODE_TYPES)
+        self.assert_verify_node_type(task_vars, group_name='execution_nodes', valid_types=EXECUTION_NODE_TYPES)
 
         result = super(ActionModule, self).run(tmp, task_vars)
         # module_args = self._task.args.copy()

--- a/awx_collection/plugins/action/generate_mesh.py
+++ b/awx_collection/plugins/action/generate_mesh.py
@@ -19,10 +19,10 @@ class ActionModule(ActionBase):
     _NODE_VALID_TYPES = {
         'automationcontroller': {
             'types': frozenset(('control', 'hybrid')),
-            'default_group': 'hybrid'},
+            'default_type': 'hybrid'},
         'execution_nodes': {
             'types': frozenset(('execution', 'hop')),
-            'default_group': 'execution'},
+            'default_type': 'execution'},
     }
 
     def ge(data=None):
@@ -101,7 +101,7 @@ class ActionModule(ActionBase):
         Members of given group_name must have a valid node_type.
         """
         if 'node_type' not in vars.keys():
-            return valid_types[group_name]['default_group']
+            return valid_types[group_name]['default_type']
 
         if vars['node_type'] not in valid_types[group_name]['types']:
             raise AnsibleError(


### PR DESCRIPTION
Upstream issue: https://github.com/ansible/tower-packaging/issues/1381

Parent PR: https://github.com/ansible/awx/pull/10779

* Working `inventory`
```ini
[automationcontroller]
controllerA.tatu.home   peers=storm.tatu.home node_type=control
controllerB.tatu.home   peers=p50.tatu.home,storm.tatu.home  node_type=control
controllerC.tatu.home   

[automationcontroller:vars]
node_type=hybrid

### receptor execution plane nodes
[execution_nodes]
storm.tatu.home   ansible_host=192.168.111.36   peers=execution_nodes
p70.tatu.home     ansible_host=192.168.111.33   peers=p50.tatu.home,storm.tatu.home
t470n1.tatu.home  ansible_host=192.168.111.34   peers=EastCoastNodes
t470n2.tatu.home  ansible_host=192.168.111.35   peers=controllerC.tatu.home
p50.tatu.home     ansible_host=192.168.111.50   peers=p90.tatu.home
p90.tatu.home     ansible_host=192.168.111.90   # no peers
```


* Adding controllerC on `execution_nodes` and `p90` on `automationcontroller`
```python
(py39) [mdemello@storm REDHAT]$ ansible-playbook  -i inventory  generate_mesh.yml 

PLAY [Generate mesh] ****************************************************************************************************************************

TASK [parse mesh] *******************************************************************************************************************************
fatal: [p50.tatu.home]: FAILED! => {"msg": "The following hosts cannot be members of both [automationcontroller] and [execution_nodes] groups: p90.tatu.home, controllerC.tatu.home"}
```

* Adding an invalid `node_type`

```python
(py39) [mdemello@storm REDHAT]$ ansible-playbook  -i inventory  generate_mesh.yml  --flush-cache

PLAY [Generate mesh] ************************************************************************************************************************************************************************************************************************************************************************************************

TASK [parse mesh] ***************************************************************************************************************************************************************************************************************************************************************************************************
fatal: [p50.tatu.home]: FAILED! => {"msg": "The host controllerC.tatu.home must have one of the valid node_types: control, hybrid"}
```