### PR TITLE
Ensure required attributes are present in the mesh data

### DIFF
--- a/awx_collection/plugins/action/calculate_mesh.py
+++ b/awx_collection/plugins/action/calculate_mesh.py
@@ -33,6 +33,15 @@ class ActionModule(ActionBase):
         },
     }
 
+    _REQUIRED_ATTRIBUTES = {
+        'receptor_log_level': 'info',
+        'receptor_control_service_name': 'control',
+        'receptor_control_filename': 'receptor.sock',
+        'receptor_listener_port': 2222,
+        'receptor_listener_protocol': 'tcp'
+    }
+
+
     def generate_control_plane_topology(self, data):
         res = defaultdict(set)
         for index, control_node in enumerate(data["groups"][self._CONTROL_PLANE]):
@@ -107,6 +116,15 @@ class ActionModule(ActionBase):
             )
         return vars["node_type"]
 
+    def assert_attributes(self, vars=None, attr=None):
+        """
+        Assert if a required attribute is present
+        otherwise return with a default value.
+        """
+        if attr not in vars.keys():
+            return self._REQUIRED_ATTRIBUTES[attr]
+        return vars[attr]
+
     def assert_unique_group(self, task_vars=None):
         """
         A given host cannot be part of the automationcontroller and execution_nodes group.
@@ -159,6 +177,12 @@ class ActionModule(ActionBase):
                     group_name=group,
                     valid_types=self._NODE_VALID_TYPES,
                 )
+
+                # ensure all receptor attributes are set
+                for attr in self._REQUIRED_ATTRIBUTES.keys():
+                    myhost_data[attr] = self.assert_attributes(
+                        vars=_host_vars,
+                        attr=attr)
                 data[host] = myhost_data
 
         return dict(mesh=data)


### PR DESCRIPTION
Upstream issue: https://github.com/ansible/tower-packaging/issues/1381

Parent PR: https://github.com/ansible/awx/pull/10779

Ensure mesh data has the required attributes

Example inventory:
```ini
[EastCoastNodes]
p50.tatu.home
p70.tatu.home

# awx node
[automationcontroller]
p50.tatu.home  node_type=control
p70.tatu.home  receptor_listener_port=2324

[automationcontroller:vars]

### receptor execution plane nodes
[execution_nodes]
t470n1.tatu.home  ansible_host=192.168.111.34   peers=EastCoastNodes
t470n2.tatu.home  ansible_host=192.168.111.35   peers=automationcontroller

# receptor vars
[execution_nodes:vars]
receptor_listener_procotol = tcp 
receptor_listener_port = 2222
receptor_log_level = debug
```
Result

```yaml
TASK [debug] ***************************************************************************************************************************************************************************************************
ok: [p50.tatu.home] => {
    "msg": {
        "changed": false,
        "failed": false,
        "mesh": {
            "p50.tatu.home": {
                "node_type": "control",
                "peers": [
                    "p70.tatu.home"
                ],
                "receptor_control_filename": "receptor.sock",
                "receptor_control_service_name": "control",
                "receptor_listener_port": 2222,
                "receptor_listener_protocol": "tcp",
                "receptor_log_level": "info"
            },
            "p70.tatu.home": {
                "node_type": "hybrid",
                "peers": [],
                "receptor_control_filename": "receptor.sock",
                "receptor_control_service_name": "control",
                "receptor_listener_port": 2324,
                "receptor_listener_protocol": "tcp",
                "receptor_log_level": "info"
            },
            "t470n1.tatu.home": {
                "node_type": "execution",
                "peers": [
                    "p50.tatu.home",
                    "p70.tatu.home"
                ],
                "receptor_control_filename": "receptor.sock",
                "receptor_control_service_name": "control",
                "receptor_listener_port": 2222,
                "receptor_listener_protocol": "tcp",
                "receptor_log_level": "debug"
            },
            "t470n2.tatu.home": {
                "node_type": "execution",
                "peers": [
                    "p50.tatu.home",
                    "p70.tatu.home"
                ],
                "receptor_control_filename": "receptor.sock",
                "receptor_control_service_name": "control",
                "receptor_listener_port": 2222,
                "receptor_listener_protocol": "tcp",
                "receptor_log_level": "debug"
            }
        }
    }
}

```